### PR TITLE
#150. FIX githubApi.getStarsAndPrs

### DIFF
--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -81,7 +81,7 @@ async function graphStarsAndPrs(): Promise<number[]> {
 // Runs the optimal graphql request if gh auth token exists
 // Falls back to the rest call without a token.
 async function getStarsAndPrs(): Promise<number[]> {
-  return TOKEN !== undefined
+  return TOKEN
     ? graphStarsAndPrs()
     : (async (): Promise<number[]> => [
         await getNumStars(),


### PR DESCRIPTION
 - now properly validates the token exists before falling back to REST endpoints for stars and prs