### PR TITLE
#150. Fix GH_TOKEN env var. 

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,9 @@
 [context.deploy-preview]
   command = "npm run build:staging"
   SITE_URL = "https://deploy-preview.zarf.dev"
-  GH_TOKEN = ''
+  GATSBY_GH_TOKEN = ''
 
 [context.branch-deploy]
   command = "npm run build:staging"
   SITE_URL = "https://develop.zarf.dev"
-  GH_TOKEN = ''
+  GATSBY_GH_TOKEN = ''

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -6,7 +6,7 @@ export interface GithubStats {
   contributors: number;
 }
 
-const TOKEN = process.env.GH_TOKEN;
+const TOKEN = process.env.GATSBY_GH_TOKEN;
 
 const octokit = new Octokit({
   auth: TOKEN,


### PR DESCRIPTION
Update the GH_TOKEN env variable to be GATSBY_GH_TOKEN in order to make available at run time.