### PR TITLE
#157. Fix quick install command. 

### DIFF
--- a/src/components/Sections/InstallZarf/utils.ts
+++ b/src/components/Sections/InstallZarf/utils.ts
@@ -14,9 +14,6 @@ export function getInstallCommand(os: OS): string[] | string {
         '',
         '# Next, you will need to deploy the Zarf Init Package',
         '$zarf init',
-        '',
-        '# You are ready to deploy any Zarf Package, try out our Retro Arcade!!',
-        '$zarf package deploy sget://defenseunicorns/zarf-hello-world:0.1.0',
       ];
       break;
   }


### PR DESCRIPTION
Removed the zarf arcade install line from the quick install command.